### PR TITLE
Health packet additions

### DIFF
--- a/examples/health.rs
+++ b/examples/health.rs
@@ -13,7 +13,10 @@ fn main() {
 
     let serial = panda.get_serial().expect("Error getting serial");
     println!("Serial: {:}", serial);
-  
+
+    let packet_versions = panda.get_packet_versions().expect("Error getting packet versions");
+    println!("Packet versions: {:?}", packet_versions);
+
 
     loop {
         if let Ok(h) = panda.health() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,13 @@ extern crate libusb;
 #[macro_use]
 extern crate bitflags;
 
-pub struct Panda<'a> {
-    device : libusb::DeviceHandle<'a>,
-    timeout : Duration,
-}
-
 const HEALTH_VERSION: u8 = 3;
+const CAN_VERSION: u8 = 1;
+
+pub struct Panda<'a> {
+    device: libusb::DeviceHandle<'a>,
+    timeout: Duration,
+}
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -141,7 +142,6 @@ bitflags! {
     }
 }
 
-const CAN_VERSION: u8 = 1;
 
 #[derive(Debug, Copy, Clone)]
 pub struct CanMessage {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub struct Health {
     pub fault_status: u8,
     pub power_save_enabled: u8,
     pub heartbeat_lost: u8,
+    pub unsafe_mode: u16,
 }
 
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub struct Health {
     pub power_save_enabled: u8,
     pub heartbeat_lost: u8,
     pub unsafe_mode: u16,
+    pub blocked_msg_cnt: u32,
 }
 
 #[repr(C)]


### PR DESCRIPTION
- add unsafe mode and blocked message counters to health packet
- add method to get packet versions (health version, CAN version)

I made a struct for PacketVersions but could also just go with `[u8; 2]`, similar to fw version? Also I'm not sure if we should check whether our CAN packet version matches the panda version now

Closes #2 