### PR TITLE
Check packet versions

### DIFF
--- a/examples/health.rs
+++ b/examples/health.rs
@@ -14,13 +14,14 @@ fn main() {
     let serial = panda.get_serial().expect("Error getting serial");
     println!("Serial: {:}", serial);
 
-    let packet_versions = panda.get_packet_versions().expect("Error getting packet versions");
+    let packet_versions = panda.get_packet_versions();
     println!("Packet versions: {:?}", packet_versions);
 
 
     loop {
-        if let Ok(h) = panda.health() {
-            println!("{:?}", h);
+        match panda.health() {
+            Ok(h) => println!("{:?}", h),
+            Err(e) => println!("Error: {}", e),
         }
         thread::sleep(Duration::from_millis(500));
     }


### PR DESCRIPTION
I'm not super familiar with rust, so there might be better ways of writing some of this, particularly retrieving the packet versions for creating the panda struct

Changes:
- get and store packet versions in `Panda` struct after opening connection to the device
~~- create a PandaError enum for `FirmwareOutdated`/`LibraryOutdated` errors and to wrap other errors, like `libusb`
~~  - changed all functions to return our own `Result<T, PandaError>`~~
- check the Health/CAN packet versions when running `health` or `can_send`/`recveive` functions